### PR TITLE
Added support for infobox creation

### DIFF
--- a/flask_googlemaps/__init__.py
+++ b/flask_googlemaps/__init__.py
@@ -4,12 +4,13 @@ from flask import render_template, Blueprint, Markup
 
 DEFAULT_ICON = '//maps.google.com/mapfiles/ms/icons/red-dot.png'
 
+
 class Map(object):
     def __init__(self, identifier, lat, lng,
                  zoom=13, maptype="ROADMAP", markers=None,
                  varname='map',
                  style="height:300px;width:300px;margin:0;",
-                 cls="map"):
+                 cls="map", **kwargs):
         self.cls = cls
         self.style = style
         self.varname = varname
@@ -20,6 +21,10 @@ class Map(object):
         if isinstance(markers, list):
             self.markers = {DEFAULT_ICON: markers}
         self.identifier = identifier
+        if 'infobox' in kwargs:
+            self.infobox = kwargs['infobox']
+        else:
+            self.infobox = None
 
     def add_marker(self, lat, lng):
         self.markers.append((lat, lng))
@@ -44,6 +49,7 @@ def googlemap_obj(*args, **kwargs):
 def googlemap(*args, **kwargs):
     map = googlemap_obj(*args, **kwargs)
     return Markup("".join((map.js, map.html)))
+
 
 def googlemap_html(*args, **kwargs):
     return googlemap_obj(*args, **kwargs).html
@@ -70,6 +76,6 @@ class GoogleMaps(object):
 
     def register_blueprint(self, app):
         module = Blueprint("googlemaps", __name__,
-            template_folder="templates")
+                           template_folder="templates")
         app.register_blueprint(module)
         return module

--- a/flask_googlemaps/__init__.py
+++ b/flask_googlemaps/__init__.py
@@ -2,7 +2,7 @@
 
 from flask import render_template, Blueprint, Markup
 
-DEFAULT_ICON = '//maps.google.com/mapfiles/ms/icons/red-dot.png'
+DEFAULT_ICON = 'http://maps.google.com/mapfiles/ms/icons/red-dot.png'
 
 
 class Map(object):
@@ -23,6 +23,10 @@ class Map(object):
         self.identifier = identifier
         if 'infobox' in kwargs:
             self.infobox = kwargs['infobox']
+            # jinja2 has no builtin for type so a flag is set to check if infobox is
+            # string or list for the template iteration
+            if type(kwargs['infobox']) is list:
+                self.typeflag = True
         else:
             self.infobox = None
 
@@ -76,6 +80,6 @@ class GoogleMaps(object):
 
     def register_blueprint(self, app):
         module = Blueprint("googlemaps", __name__,
-                           template_folder="templates")
+            template_folder="templates")
         app.register_blueprint(module)
         return module

--- a/flask_googlemaps/templates/googlemaps/gmapjs.html
+++ b/flask_googlemaps/templates/googlemaps/gmapjs.html
@@ -21,8 +21,13 @@
                     icon: "{{ icon }}"
                 });
                 {% if gmap.infobox != None %}
-                        google.maps.event.addListener(marker_{{loop.index0}}, 'click',
-                        getInfoCallback({{gmap.varname}}, "{{gmap.infobox[loop.index0]|safe}}"));
+                        {% if gmap.typeflag %}
+                            google.maps.event.addListener(marker_{{loop.index0}}, 'click',
+                            getInfoCallback({{gmap.varname}}, "{{gmap.infobox[loop.index0]|safe}}"));
+                        {% else %}
+                            google.maps.event.addListener(marker_{{loop.index0}}, 'click',
+                            getInfoCallback({{gmap.varname}}, "{{gmap.infobox|safe}}"));
+                        {% endif %}
                 {% endif %}
             {% endfor %}
         {% endfor %}
@@ -36,6 +41,5 @@
             };
     }
     google.maps.event.addDomListener(window, 'load', initialize_{{gmap.varname}});
-
 
 </script>

--- a/flask_googlemaps/templates/googlemaps/gmapjs.html
+++ b/flask_googlemaps/templates/googlemaps/gmapjs.html
@@ -1,4 +1,4 @@
-<script src="//maps.googleapis.com/maps/api/js?sensor=false" type="text/javascript"></script>
+<script src="http://maps.googleapis.com/maps/api/js?sensor=false" type="text/javascript"></script>
 
 <style type="text/css">
       #{{gmap.identifier}} { {{gmap.style}} }
@@ -14,15 +14,28 @@
         });
 
         {% for icon in gmap.markers %}
-        {% for marker in gmap.markers[icon] %}
-            var marker_{{loop.counter}} = new google.maps.Marker({
-                position: new google.maps.LatLng({{marker.0}}, {{marker.1}}),
-                map: {{gmap.varname}},
-                icon: "{{ icon }}"
-            });
+            {% for marker in gmap.markers[icon] %}
+                var marker_{{loop.index0}} = new google.maps.Marker({
+                    position: new google.maps.LatLng({{marker.0}}, {{marker.1}}),
+                    map: {{gmap.varname}},
+                    icon: "{{ icon }}"
+                });
+                {% if gmap.infobox != None %}
+                        google.maps.event.addListener(marker_{{loop.index0}}, 'click',
+                        getInfoCallback({{gmap.varname}}, "{{gmap.infobox[loop.index0]|safe}}"));
+                {% endif %}
+            {% endfor %}
         {% endfor %}
-        {% endfor %}
+    }
 
+    function getInfoCallback(map, content) {
+        var infowindow = new google.maps.InfoWindow({content: content});
+        return function() {
+                infowindow.setContent(content);
+                infowindow.open(map, this);
+            };
     }
     google.maps.event.addDomListener(window, 'load', initialize_{{gmap.varname}});
+
+
 </script>


### PR DESCRIPTION
**This resolves issue #2**

Users should now be able to create infoboxes in python and have them displayed in a map. You can specify the optional argument `infobox` when creating a `Map` instance to have infoboxes for markers enabled. Pass in normal text or html to this parameter to format the infobox. I have provided an example where I pass in a list of images assigned to various lat/longs. There is also support for a single string value for infobox (so if you have four markers but only specify one string value for infobox, all markers will have the same infobox). This required some...umm...jankification as jinja2 has no builtin for `type()` to check if `infobox` is a list or string. I ended up creating a flag and checking it in `__init__.py`. 

Here's an example snippet of code: 
<img width="846" alt="screen shot 2015-07-29 at 2 55 53 pm" src="https://cloud.githubusercontent.com/assets/8108300/8969636/01994d80-3602-11e5-80ba-e0aa707b63a3.png">

Which results in the following map:
<img width="1439" alt="screen shot 2015-07-29 at 2 41 52 pm" src="https://cloud.githubusercontent.com/assets/8108300/8969650/13b0de7a-3602-11e5-9ed0-9f328ac9253f.png">

I hope this helps, I created it to suit my own interests (which are unrelated to the animal images above) but felt you might want to take a look. Thanks for creating an easy to read codebase! :+1: 