### PR TITLE
Fix bug that returns attribute error when lat or long is exactly 0

### DIFF
--- a/flask_googlemaps/__init__.py
+++ b/flask_googlemaps/__init__.py
@@ -98,9 +98,9 @@ class Map(object):
         return marker_dict
 
     def add_marker(self, lat=None, lng=None, **kwargs):
-        if lat != None:
+        if lat is not None:
             kwargs['lat'] = lat
-        if lng != None:
+        if lng is not None:
             kwargs['lng'] = lng
         if 'lat' not in kwargs or 'lng' not in kwargs:
             raise AttributeError('lat and lng required')

--- a/flask_googlemaps/__init__.py
+++ b/flask_googlemaps/__init__.py
@@ -98,9 +98,9 @@ class Map(object):
         return marker_dict
 
     def add_marker(self, lat=None, lng=None, **kwargs):
-        if lat:
+        if lat != None:
             kwargs['lat'] = lat
-        if lng:
+        if lng != None:
             kwargs['lng'] = lng
         if 'lat' not in kwargs or 'lng' not in kwargs:
             raise AttributeError('lat and lng required')


### PR DESCRIPTION
Hi! I was using this package but I ran into problems when lat or lng was exactly 0 and the lat and lng were passed in as arguments (not in kwargs). This is because (if 0) resolves to False. 