### PR TITLE
Add toggle for map.fitBounds() - closes issue #55

### DIFF
--- a/flask_googlemaps/__init__.py
+++ b/flask_googlemaps/__init__.py
@@ -36,6 +36,7 @@ class Map(object):
                  cluster=False,
                  cluster_imagepath=DEFAULT_CLUSTER_IMAGE_PATH,
                  cluster_gridsize=60,
+                 fit_markers_to_bounds=False,
                  **kwargs):
         """Builds the Map properties"""
         self.cls = cls
@@ -69,6 +70,8 @@ class Map(object):
         self.cluster = cluster
         self.cluster_imagepath = cluster_imagepath
         self.cluster_gridsize = cluster_gridsize
+
+        self.fit_markers_to_bounds = fit_markers_to_bounds
 
     def build_markers(self, markers):
         if not markers:
@@ -723,6 +726,7 @@ class Map(object):
             'collapsible': self.collapsible,
             'js': dumps(self.js),
             'html': dumps(self.html),
+            'fit_markers_to_bounds': self.fit_markers_to_bounds,
         }
 
         return json_dict

--- a/flask_googlemaps/templates/googlemaps/gmapjs.html
+++ b/flask_googlemaps/templates/googlemaps/gmapjs.html
@@ -62,6 +62,15 @@
            }
         }
 
+        {% if gmap.fit_markers_to_bounds %}
+            // fit all markers in bounds
+            var {{gmap.varname}}_bounds = new google.maps.LatLngBounds();
+            for(i=0; i<{{gmap.varname}}_markers.length;i++) {
+                {{gmap.varname}}_bounds.extend({{gmap.varname}}_markers[i].getPosition());
+            };
+            {{gmap.varname}}.fitBounds({{gmap.varname}}_bounds);
+        {% endif %}
+
         // add rectangles
         var raw_rectangles = {{ gmap.rectangles|tojson|safe }};
         for(i = 0; i < {{ gmap.rectangles|length }}; i++) {
@@ -139,7 +148,7 @@
                 );
            }
         }
-    
+
         // add polylines
         var raw_polylines = {{ gmap.polylines|tojson|safe }};
         for(i = 0; i < {{ gmap.polylines|length }}; i++) {
@@ -179,7 +188,7 @@
             infowindow.open(map, this);
         };
     }
-    
+
     {% if gmap.collapsible %}
         function init_{{gmap.identifier}}_button() {
             document.getElementById('{{gmap.identifier}}').style.display = 'none';


### PR DESCRIPTION
Allow users to easily fit all markers within view on page load

### Without bounds
```python
@app.route('/map-unbounded/')
def map_unbounded():
"""Create map with markers out of bounds."""
    locations = []    # long list of coordinates
    map = Map(
        lat=locations[0].latitude,
        lng=locations[0].longitude,
        markers=[(loc.latitude, loc.longitude) for loc in locations]
    )
    return render_template('map.html', map=map)
```
![image](https://user-images.githubusercontent.com/14223309/29294427-24a8d4e0-8104-11e7-967b-0c55c20d0f7c.png)

### With bounds
```python
@app.route('/map-bounded/')
def map_bounded():
"""Create map with all markers within bounds."""
    locations = []    # long list of coordinates
    map = Map(
        lat=locations[0].latitude,
        lng=locations[0].longitude,
        markers=[(loc.latitude, loc.longitude) for loc in locations],
        fit_markers_to_bounds = True
    )
    return render_template('map.html', map=map)
```
![image](https://user-images.githubusercontent.com/14223309/29294483-6ac3e532-8104-11e7-988c-5c19d700fe5b.png)
